### PR TITLE
changed protobuf gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,29 +2,15 @@ PATH
   remote: .
   specs:
     nats_listener (0.1.0)
+      google-protobuf
       nats-pure
-      protobuf
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    concurrent-ruby (1.0.5)
     diff-lcs (1.3)
-    i18n (1.1.0)
-      concurrent-ruby (~> 1.0)
-    middleware (0.1.0)
-    minitest (5.11.3)
+    google-protobuf (3.6.1)
     nats-pure (0.5.0)
-    protobuf (3.8.4)
-      activesupport (>= 3.2)
-      middleware
-      thor
-      thread_safe
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -39,10 +25,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    thor (0.20.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/nats_listener.gemspec
+++ b/nats_listener.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_dependency 'nats-pure'
-  spec.add_dependency 'protobuf'
+  spec.add_dependency 'google-protobuf'
 end


### PR DESCRIPTION
As I found from [https://github.com/nats-io/ruby-nats-streaming](Stan) - Stan uses google/protobuf. So it's nice to use this gem instead of just `protobuf` gem.