### PR TITLE
added nats-streaming gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     nats_listener (0.1.0)
       google-protobuf
       nats-pure
+      nats-streaming
 
 GEM
   remote: https://rubygems.org/
@@ -11,6 +12,9 @@ GEM
     diff-lcs (1.3)
     google-protobuf (3.6.1)
     nats-pure (0.5.0)
+    nats-streaming (0.2.2)
+      google-protobuf (~> 3)
+      nats-pure (~> 0)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)

--- a/nats_listener.gemspec
+++ b/nats_listener.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_dependency 'nats-pure'
   spec.add_dependency 'google-protobuf'
+  spec.add_dependency 'nats-streaming'
 end


### PR DESCRIPTION
For streaming subscribers we need `nats-streaming` gem.
Later it will be used for special subscribers functionality.